### PR TITLE
Matic is not the offical name, so change to polygon?

### DIFF
--- a/src/containers/modal/ModalNetwork/index.tsx
+++ b/src/containers/modal/ModalNetwork/index.tsx
@@ -12,11 +12,11 @@ export const ModalNetwork:React.FC = () => {
 
   return (
     <div className={styles.wrap}>
-      <p className={styles.title}>You should switch to Matic network</p>
+      <p className={styles.title}>You should switch to Polygon network</p>
       <ul className={styles.params}>
         <li>
           <span className={styles.label}>name - </span>
-          Matic
+          Polygon
         </li>
         <li>
           <span className={styles.label}>chainId - </span>
@@ -24,7 +24,7 @@ export const ModalNetwork:React.FC = () => {
         </li>
         <li>
           <span className={styles.label}>RPC URL - </span>
-          https://rpc-mainnet.matic.network
+          https://polygon-rpc.com
 
         </li>
         <li>
@@ -34,7 +34,7 @@ export const ModalNetwork:React.FC = () => {
       </ul>
       <Button 
         onClick={handleClick}
-        label="SWITCH TO MATIC"
+        label="SWITCH TO POLYGON"
         className={styles.button}
       />
     </div>


### PR DESCRIPTION
https://polygon-rpc.com from here:

https://blog.polygon.technology/polygon-rpc-gateway-will-provide-a-free-high-performance-connection-to-the-polygon-pos-blockchain/

also used here: https://docs.superfluid.finance/superfluid/networks/polygon-network-matic