### PR TITLE
Display user flows first to solve #46

### DIFF
--- a/src/containers/main/InvestContainer/index.tsx
+++ b/src/containers/main/InvestContainer/index.tsx
@@ -32,6 +32,15 @@ export const InvestContainer :React.FC = () => {
   ) => {
     dispatch(stopFlowAction(config, callback));
   }, [dispatch, balances]);
+  
+  // Sort flows given their placeholder float value
+  flowConfig.sort(
+    (a, b) => {
+      const flowA = parseFloat(state[a.flowKey]?.placeholder || '0'); 
+      const flowB = parseFloat(state[b.flowKey]?.placeholder || '0');
+      return flowB - flowA;
+    },
+  );
 
   const handleSearch = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;


### PR DESCRIPTION
Sort flowConfig array so that user flows are displayed first (those with a stream > 0, sorted on monthly stream amount) to solve #46

![image](https://user-images.githubusercontent.com/16822841/140324495-306f97eb-0529-4d97-8705-322c72746da1.png)
