### PR TITLE
Add a tooltip to warn user about deposit to fix #28

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-router-dom": "5.2.0",
     "react-scripts": "4.0.3",
     "react-toastify": "7.0.3",
+    "react-tooltip": "^4.2.21",
     "redux": "4.0.5",
     "redux-persist": "^6.0.0",
     "redux-saga": "^1.1.3",

--- a/src/components/layout/CoinRateForm/index.tsx
+++ b/src/components/layout/CoinRateForm/index.tsx
@@ -4,6 +4,7 @@ import React, {
   FC,
 } from 'react';
 import { useTranslation } from 'i18n';
+import ReactTooltip from 'react-tooltip';
 import ButtonNew from '../../common/ButtonNew';
 import { Coin } from '../../../constants/coins';
 import styles from './styles.module.scss';
@@ -38,7 +39,7 @@ export const CoinRateForm: FC<IProps> = ({
       </div>
       <div className={styles.buttons}>
         <div className={styles.start_wrap}>
-          <ButtonNew color="primary" onClick={onClickStart} className={styles.start} disabled={isLoading}>
+          <ButtonNew color="primary" onClick={onClickStart} className={styles.start} disabled={isLoading} data-tip data-for="depositTooltip">
             {t('Start')}
             /
             {t('Edit')}
@@ -47,6 +48,32 @@ export const CoinRateForm: FC<IProps> = ({
         <div className={styles.stop_wrap}>
           <ButtonNew color="secondary" onClick={onClickStop} className={styles.stop} disabled={isLoading}>{t('Stop')}</ButtonNew>
         </div>
+        <div style={{ flexBasis: '100%', height: '0' }}> </div>
+
+        { parseFloat(value) > 0 ? (
+          <ReactTooltip 
+            id="depositTooltip" 
+            place="right" 
+            effect="solid" 
+            multiline
+            className={styles.depositTooltip}
+          >
+            <span
+              className={styles.depositTooltip_span}
+            >
+              Starting this stream will take a security deposit of 
+              <span style={{ fontWeight: 700 }}> 
+                {` ${(parseFloat(value) * 0.05555).toFixed(2)} ${coin} `}
+              </span>
+              from your balance. 
+              The Deposit will be refunded in full when you close the stream or lost if 
+              your balance hits zero with the stream still open.
+
+            </span> 
+          </ReactTooltip>
+        )
+          : null }
+        <div />
       </div>
     </div>
   );

--- a/src/components/layout/CoinRateForm/styles.module.scss
+++ b/src/components/layout/CoinRateForm/styles.module.scss
@@ -95,3 +95,18 @@
     
   }
 }
+
+.depositTooltip_span {
+  width: 500px;
+  display: block;
+  text-align: justify;
+  opacity: 0.8;
+  font-size: 0.95em;
+  background: var(--color-blue);
+}
+.depositTooltip {
+  background: var(--color-blue) !important;
+}
+.__react_component_tooltip::before, .__react_component_tooltip::after {
+  border-top: 5px solid #062e56 !important;
+}


### PR DESCRIPTION
Add a tooltip to warn user about deposit to fix #28
Tooltip is only displayed when mouse cursor hovers over the start button and stream is greater than zero.

![image](https://user-images.githubusercontent.com/16822841/140440342-4b8a85e5-818f-4902-a364-84d08b5894cc.png)

