### PR TITLE
Bugfix upgrade usdc

### DIFF
--- a/src/store/main/sagas/upgradeSaga.ts
+++ b/src/store/main/sagas/upgradeSaga.ts
@@ -39,9 +39,10 @@ export function* upgradeMainSaga({ payload }: ReturnType<typeof upgradeAction>) 
   try {
     yield put(mainSetState({ isLoadingUpgrade: true }));
     const {
-      superTokenAddress, value, multi,
+      superTokenAddress, value,
     } = payload;
-    const amount = web3.utils.toWei((Number(value) * multi).toString(), 'wei');
+    // Superfluid upgrade contract requires the upgrade value to be scaled by 1e18 and not decimals
+    const amount = web3.utils.toWei((Number(value) * 1e18).toString(), 'wei'); 
     yield call(upgradeSaga, superTokenAddress, amount);
     payload.callback();
     yield all([


### PR DESCRIPTION
Fixes #89 

The superfluid upgrade contract (wrapping USDC to USDCx, etc) needs values with 18 decimals, independently of the decimal count of the inherent token to be upgraded. So WETH, DAI or USDC all need to be scaled by 1e18 to be accepted.