### PR TITLE
Increase decimal count for deposit warning message token amount

### DIFF
--- a/src/components/layout/CoinRateForm/index.tsx
+++ b/src/components/layout/CoinRateForm/index.tsx
@@ -63,7 +63,7 @@ export const CoinRateForm: FC<IProps> = ({
             >
               Starting this stream will take a security deposit of 
               <span style={{ fontWeight: 700 }}> 
-                {` ${(parseFloat(value) / 180.0).toFixed(2)} ${coin} `}
+                {` ${(parseFloat(value) / 180.0).toFixed(6)} ${coin} `}
               </span>
               from your balance. 
               The Deposit will be refunded in full when you close the stream or lost if 


### PR DESCRIPTION
Set it to 6 decimals just like most of the values shown in the page
![Screenshot 2021-12-02 at 01 35 39](https://user-images.githubusercontent.com/77115130/144331276-420a5250-b700-41e5-bfce-868eb1bd1a28.png)
