### PR TITLE
center the upgrade and downgrade icons

### DIFF
--- a/src/containers/main/UpgradeContainer/styles.module.scss
+++ b/src/containers/main/UpgradeContainer/styles.module.scss
@@ -108,7 +108,7 @@
   border-radius: 4px;
   background-color: rgba(16,187,52,.15);
   cursor: pointer;
-  padding: 4px;
+  padding: 3px;
   color: #10bb34;
   font-size: 15px;
 }
@@ -122,7 +122,7 @@
   display: inline-block;
   border-radius: 4px;
   cursor: pointer;
-  padding: 4px;
+  padding: 0px;
   background-color: rgba(229,26,69,.15);
 
 }


### PR DESCRIPTION
The issue (https://github.com/Ricochet-Exchange/ricochet-frontend/issues/182) has been resolved in this pull request. 