### PR TITLE
Expand input field on Wallet page

### DIFF
--- a/src/components/layout/UpgradePanel/styles.module.scss
+++ b/src/components/layout/UpgradePanel/styles.module.scss
@@ -71,6 +71,8 @@
   color: var(--color-grey);
   padding: 10px 0 11px 20px;
   border-radius: 8px;
+  -moz-appearance:textfield;
+  width: 25ch;
 }
 
 .container_input {


### PR DESCRIPTION
#218 

Issue appeared only in Firefox.

![before](https://user-images.githubusercontent.com/43212351/151048252-cb547cdd-ae0f-404c-b510-eb8596936f42.png)

![after](https://user-images.githubusercontent.com/43212351/151048249-43530e08-0a66-4117-82f5-3e4d6c08f50a.png)



Also hid spinner in Firefox for consistency.

