### PR TITLE
fix: removed deprecated 'wait' option.

### DIFF
--- a/src/i18n/utils/index.ts
+++ b/src/i18n/utils/index.ts
@@ -36,7 +36,6 @@ i18n
       escapeValue: false,
     },
     react: {
-      wait: true,
       useSuspense: true,
     },
   });


### PR DESCRIPTION
fixed #331 

see more details here: [`useSuspense` instead of `wait`](https://github.com/i18next/react-i18next/blob/e91ed946979d8a27cf0dd255c5ac7e516e02c073/src/useTranslation.js#L21-L24)