### PR TITLE
fix: center align coin image in wallet page

### DIFF
--- a/src/containers/main/UpgradeContainer/styles.module.scss
+++ b/src/containers/main/UpgradeContainer/styles.module.scss
@@ -77,16 +77,14 @@
 }
 .currDisplay {  
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   flex-direction: row;
   gap: 5px;
-  
 }
 
 .currDisplayImg {
-  width: 24px;
-  height: 24px;
- 
+  width: 18px;
+  height: 18px;
 }
 
 .currDisplayName {


### PR DESCRIPTION
Closes #359

![Screenshot 2022-02-11 at 4 23 03 PM](https://user-images.githubusercontent.com/69431456/153579271-5eb0550a-d9c0-44ed-95e4-20e84c5a5b31.png)
