### PR TITLE
fix: hide balance while loading in rex-launchpad page

### DIFF
--- a/src/components/common/Price/index.tsx
+++ b/src/components/common/Price/index.tsx
@@ -31,7 +31,9 @@ export default function Price(props: Props) {
     if (web3?.currentProvider === null) return;
     getPrice(web3).then((p) => setPrice(p));
   });
-  
+
+  if (!price) return null;
+
   return (
     <div className={styles.balance_container}>
       <span {...props} className={styles.balance}>{`🚀 ${trimPad(price, 2)} USDC/RIC`}</span>


### PR DESCRIPTION
Fixes #367

https://user-images.githubusercontent.com/69431456/153889875-35b07f5e-b2de-44b4-b5bc-cca69d8f4451.mov

