### PR TITLE
fix tokens alignment

### DIFF
--- a/src/components/layout/CoinChange/styles.module.scss
+++ b/src/components/layout/CoinChange/styles.module.scss
@@ -11,8 +11,8 @@
 
   & .img_usd,
   .img_bitcoin {
-    position: absolute;
-    width: 32px;
+    // position: absolute;
+    // width: 32px;
     padding: 0;
     background: transparent;
     border: none;
@@ -20,7 +20,7 @@
 }
 
 .img_bitcoin {
-  left: 22px;
+  // left: 22px;
 
   &:active {
     background: var(--color-blue-light);
@@ -28,7 +28,7 @@
 }
 
 .img_usd {
-  left: 0px;
+  // left: 0px;
 
   &:active {
     background: var(--color-blue-light);
@@ -36,9 +36,13 @@
 }
 
 .currency_name_container {
-  width: 100%;
-  padding:1em;
-  padding-left: 5em;
+  width: 186px;
+  padding: 1em;
+  padding-left: 2em;
+  @include tablet {
+    width: 150px;
+    padding-left: 1em;
+  }
 }
 .currency_name {
   @include flexbox(center, flex-start);
@@ -47,6 +51,7 @@
 
   @include tablet {
     flex-wrap: nowrap;
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
fixes #509 

<img width="317" alt="Screenshot 2022-02-26 at 10 41 47 PM" src="https://user-images.githubusercontent.com/55599878/155852404-79b3a8bf-a749-437b-9075-2bc6c63d50f5.png">

for etherium image, there's already a space inside of the svg image

<img width="27" alt="Screenshot 2022-02-26 at 10 09 46 PM" src="https://user-images.githubusercontent.com/55599878/155852507-eb9418cb-14ff-472a-a8c4-ca28caf69369.png">

