### PR TITLE
Add Lighthouse CI for website benchmarking to GitHub Actions

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,31 @@
+name: Lighthouse CI
+
+on:
+  workflow_dispatch:
+  pull_request_target:
+    types: [reopened, opened, synchronize, edited]
+  
+env:
+  NODE_OPTIONS: --max-old-space-size=8192
+
+jobs:
+  lighthouseci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - run: yarn install && npm install -g @lhci/cli@0.8.x
+      - run: yarn build
+      - name: run lighthouse action
+        id: lighthouse-report
+        run: |
+          echo "::set-output name=MESSAGE::$(lhci autorun | grep https://storage)"
+          
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            - ${{ steps.lighthouse-report.outputs.MESSAGE }}

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -1,0 +1,13 @@
+"use strict";
+
+module.exports = {
+  ci: {
+    collect: {
+      numberOfRuns: 1,
+      staticDistDir: "./build",
+    },
+    upload: {
+      target: "temporary-public-storage",
+    },
+  },
+};


### PR DESCRIPTION
Fixes #508 

**Changes proposed in this pull request:**

- Integrated Lighthouse CI with GitHub Actions
- Temporary Link is generated each time a pull request is created/updated and commented in the same PR thread

Tested to be working in PR: https://github.com/hrishibhattu/ricochet-frontend/pull/2#issuecomment-1053634452

Issue fixed with @geekypandey 😀 