### PR TITLE
Fixing bank vault UI bugs

### DIFF
--- a/src/components/banks/ApproveToken/index.tsx
+++ b/src/components/banks/ApproveToken/index.tsx
@@ -20,6 +20,7 @@ export const ApproveToken: FC<Props> = ({
       <LoadingWrapper
         isLoading={isLoadingApprove}
         classNameLoader={styles.loader}
+        loadingType="spinner"
       >
         <Button
           className={styles.button}

--- a/src/components/banks/VaultTransaction/index.tsx
+++ b/src/components/banks/VaultTransaction/index.tsx
@@ -68,6 +68,7 @@ export const VaultTransaction: FC<Props> = ({
         isLoading={isLoadingTransaction}
         className={styles.fullframe}
         classNameLoader={styles.loader}
+        loadingType="spinner"
       >
         <>
           <div className={styles.VaultTransaction__preview}>

--- a/src/components/common/LoadingPopUp/styles.module.scss
+++ b/src/components/common/LoadingPopUp/styles.module.scss
@@ -5,7 +5,7 @@
     width: 30vw;
     background-color: #EDF3FB;
     padding: 1em;
-    border-top: 20px solid #6F767E;
+    border-top: 20px solid #6f767ed9;
     border-bottom: 20px solid #6F767E;
     border-radius: 25px;
     color: rgb(42, 42, 42);
@@ -13,9 +13,6 @@
     align-items: center;
     justify-content: center;
     flex-direction: column;
-    box-shadow: 10px 25px 79px 4px rgba(155,150,150,0.82);
-    -webkit-box-shadow: 10px 25px 79px 4px rgba(155,150,150,0.82);
-    -moz-box-shadow: 10px 25px 79px 4px rgba(155,150,150,0.82);
     animation: popup 0.2s linear;
     text-align: center;
   }
@@ -65,9 +62,6 @@
     align-items: center;
     justify-content: center;
     flex-direction: column;
-    box-shadow: 10px 25px 79px 4px rgba(155,150,150,0.82);
-    -webkit-box-shadow: 10px 25px 79px 4px rgba(155,150,150,0.82);
-    -moz-box-shadow: 10px 25px 79px 4px rgba(155,150,150,0.82);
     animation: popup 0.2s linear;
     text-align: center;
     margin-top: 1em;

--- a/src/components/common/LoadingWrapper/index.tsx
+++ b/src/components/common/LoadingWrapper/index.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import cx from 'classnames';
 import { LoadingPopUp } from 'components/common/LoadingPopUp';
+import { Loader } from '../Loader';
 import styles from './styles.module.scss';
 
 type Props = {
   isLoading?: boolean;
   className?: string;
   classNameLoader?: string;
+  loadingType?: string;
 };
 
 export const LoadingWrapper: React.FC<Props> = ({
@@ -14,12 +16,16 @@ export const LoadingWrapper: React.FC<Props> = ({
   isLoading,
   className,
   classNameLoader,
+  loadingType,
 }) => (
+
   <div className={cx(styles.wrap, className)}>
     {children}
     {isLoading && (
     <div className={cx(styles.loader, classNameLoader)}>
-      <LoadingPopUp />
+      {
+        loadingType !== 'spinner' && loadingType !== '' ? <LoadingPopUp /> : <Loader />
+      }
     </div>
     )}
   </div>

--- a/src/components/common/LoadingWrapper/styles.module.scss
+++ b/src/components/common/LoadingWrapper/styles.module.scss
@@ -6,9 +6,6 @@
 }
 
 .loader {
-  position: fixed;
-  top: 0;
-  right: 10;
   width: 100%;
   height: 100%;;
   @include flexbox(center, center);

--- a/src/containers/main/BanksContainer/index.tsx
+++ b/src/containers/main/BanksContainer/index.tsx
@@ -101,7 +101,7 @@ export const BanksContainer = () => {
           : 
           (
             <div className={styles.sign_container}>
-              <p>{t('Sign in to see the bank')}</p>
+              <p className={styles.sign_in_text}>{t('Sign in to see the bank')}</p>
               <SignInButton
                 onClick={handleSignIn}
               />

--- a/src/containers/main/BanksContainer/styles.module.scss
+++ b/src/containers/main/BanksContainer/styles.module.scss
@@ -127,6 +127,10 @@
   padding: 2em;
 }
 
+.sign_in_text{
+  text-align: center;
+}
+
 @media only screen and (min-width: 1824px) {
   .BankDetails {
     margin-top: 20px;

--- a/src/containers/main/VaultsContainer/index.tsx
+++ b/src/containers/main/VaultsContainer/index.tsx
@@ -24,10 +24,6 @@ export const VaultsContainer = () => {
   const [activeTransaction, setActiveTransaction] = useState('');
   const [transactionHash, setTransactionHash] = useState('');
   const { t } = useTranslation();
-
-  useEffect(() => {
-    if (!banks[0]) dispatch(banksGetData());
-  }, [banks]);
   
   const handleOnClick = useCallback((e: MouseEvent) => {
     e.preventDefault();
@@ -37,6 +33,10 @@ export const VaultsContainer = () => {
   const handleSignIn = useCallback(() => {
     dispatch(connectWeb3Modal());
   }, [dispatch]);
+  
+  useEffect(() => {
+    if (!banks[0]) dispatch(banksGetData());
+  }, [banks]);
 
   useEffect(() => {
     if (banks) {
@@ -74,6 +74,7 @@ export const VaultsContainer = () => {
             <LoadingWrapper
               isLoading={isLoading}
               className={styles.fullframe}
+              loadingType="spinner"
             >
               <div className={styles.contentTotal}>
                 {hasVault ? (


### PR DESCRIPTION
Fixes #

**Changes proposed in this pull request:**

-   Removed box shadow from loading wrapper component to avoid cutoff 
Resolved issue:
![fault1](https://user-images.githubusercontent.com/69639595/156052374-1a159d0a-f52d-4480-9b3a-f39be94c6984.png)

-   Allowed for LoadingWrapper to display one of two components depending on a prop called:  loadingType
    
If loadingType is 'spinner' the Loader animation will be rendered
Else we render the LoadingPopUp component

Issue solved: 

https://user-images.githubusercontent.com/69639595/156052939-ff9f745b-785f-4fdd-9633-b877ecd52770.mov

- Aligned the Bank page sign in prompt
 
   Issue solved:

![fault3](https://user-images.githubusercontent.com/69639595/156053111-7a06ed47-7397-4c03-a424-f5db62abafd2.jpg)

