### PR TITLE
Fix bank repay

### DIFF
--- a/src/containers/main/VaultTransactionContainer/index.tsx
+++ b/src/containers/main/VaultTransactionContainer/index.tsx
@@ -80,7 +80,7 @@ export const VaultTransactionContainer: FC<Props> = ({
 
   const handleApproveToken = useCallback(() => {
     dispatch(banksApproveToken(
-      bank.collateralToken.address,
+      bank.debtToken.address,
       bank.bankAddress,
       bank.vault.debtAmount,
       callbackApprove,


### PR DESCRIPTION
Fixes #520 

[Commit that introduced bug](https://github.com/Ricochet-Exchange/ricochet-frontend/commit/b7ac5f9c89b5de6162a96f2b3cf0dac4ba5b434a#diff-e49f7744ff4d1284ee0a0ffa420e48e3bf67aaaef9177eb66bd8c5f39c3425f6R77)

This has been broken from the start, the screenshot provided in #287 is actually a reproduction of this bug, as it triggered approval for the collateral token (RIC) instead of debt token (USDCx).
