### PR TITLE
Stats dont load

### DIFF
--- a/src/containers/main/UpgradeContainer/index.tsx
+++ b/src/containers/main/UpgradeContainer/index.tsx
@@ -23,7 +23,7 @@ import { queryFlows } from '../../../api';
 import { Flow } from '../../../types/flow';
 
 function getFormattedNumber(num: string) {
-  return parseFloat(num).toString().replace(/\B(?=(\d{3})+(?!\d))/g, '');
+  return parseFloat(num).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 }
 
 interface IProps {

--- a/src/store/main/sagas/loadReadOnlyData.ts
+++ b/src/store/main/sagas/loadReadOnlyData.ts
@@ -16,6 +16,7 @@ export function* loadReadOnlyData() {
       isLoading: false,
     }));
   } catch (e) {
+    console.log('reached', e);
     if (process.env.REACT_APP_API_NODE_URL) yield put(mainGetReadOnlyData());
     else if (e instanceof Error) {
       throw new Error(`Missing mandatory environment variable REACT_APP_API_NODE_URL. Error: ${e?.message}`);

--- a/src/utils/getQueryStreams.ts
+++ b/src/utils/getQueryStreams.ts
@@ -1,6 +1,6 @@
 export const getQueryStreams = (sender: string) => `{
     streams(
-      where: { sender: "${sender.toLowerCase()}" }
+      where: { sender: "${sender?.toLowerCase()}" }
     ) {
        id
         createdAtTimestamp


### PR DESCRIPTION
getQueryStreams sender could be undefined causing query to fail, browser to freeze on metamask and stats not to load.

Added check to see if sender is undefined and if so to then convert to lowers case otherwise just make the query