### PR TITLE
fix: trades page

### DIFF
--- a/src/containers/main/TradeHistory/TradeHistory.tsx
+++ b/src/containers/main/TradeHistory/TradeHistory.tsx
@@ -165,9 +165,6 @@ export function TradeHistoryTable({ address }: TradeHistoryProps) {
 		setRowsPerPage(+event.target.value);
 		setPage(0);
 	};
-
-	return <div>TODO</div>;
-
 	if (queryingStreams || queryingStreamPeriods || queryingCreatedStreams || queryingDistributions) {
 		return <Skeleton animation="wave" width={'100%'} height={80} />;
 	}

--- a/src/containers/main/TradeHistory/TradeHistory.tsx
+++ b/src/containers/main/TradeHistory/TradeHistory.tsx
@@ -108,7 +108,7 @@ export function TradeHistoryTable({ address }: TradeHistoryProps) {
 		variables: {
 			id_in:
 				terminatedStreams && terminatedStreams.streams.length
-					? [...terminatedStreams.streams].map((data) => data.stream.id)
+					? [...new Set([...terminatedStreams.streams].map((data) => data.stream.id))]
 					: [],
 		},
 	});

--- a/src/containers/main/TradeHistory/data/queries.ts
+++ b/src/containers/main/TradeHistory/data/queries.ts
@@ -25,27 +25,24 @@ export const GET_STREAMS_CREATED = gql`
 export const GET_STREAMS_WITH_FLOW_UPDATED_EVENTS = gql`
 	query GetStreamsWithFlowUpdatedEvents($sender: String!, $receivers: [String!]!) {
 		streams: flowUpdatedEvents(
-			where: { sender: $sender, receiver_in: $receivers }
+			where: { receiver_in: $receivers, sender: $sender }
 			orderBy: timestamp
 			orderDirection: desc
-			first: 100
 		) {
-			type
 			stream {
-				id
-				createdAtTimestamp
-				streamedUntilUpdatedAt
-				updatedAtTimestamp
-				token {
-					symbol
-					id
+				streamPeriods(
+					where: { stoppedAtTimestamp_not: null }
+					orderBy: startedAtTimestamp
+					orderDirection: desc
+				) {
+					startedAtTimestamp
+					stoppedAtTimestamp
+					token {
+						symbol
+					}
+					totalAmountStreamed
 				}
 			}
-			receiver
-			timestamp
-			totalAmountStreamedUntilTimestamp
-			transactionHash
-			id
 		}
 	}
 `;
@@ -57,6 +54,9 @@ export const GET_STREAM_PERIODS = gql`
 			orderBy: startedAtTimestamp
 			orderDirection: desc
 		) {
+			receiver {
+				id
+			}
 			startedAtTimestamp
 			stoppedAtTimestamp
 			totalAmountStreamed
@@ -68,10 +68,10 @@ export const GET_STREAM_PERIODS = gql`
 `;
 
 export const GET_DISTRIBUTIONS = gql`
-	query GetUserDistributionSubscriptions($subscriber: String!, $updatedAtTimestamps: [String!]!) {
+	query GetUserDistributionSubscriptions($subscriber: String!) {
 		distributions: indexSubscriptions(
 			first: 1000
-			where: { subscriber: $subscriber, updatedAtTimestamp_in: $updatedAtTimestamps }
+			where: { subscriber: $subscriber }
 			orderBy: createdAtTimestamp
 			orderDirection: desc
 		) {
@@ -84,6 +84,7 @@ export const GET_DISTRIBUTIONS = gql`
 			indexValueUntilUpdatedAt
 			units
 			index {
+				id
 				publisher {
 					id
 				}
@@ -99,6 +100,18 @@ export const GET_DISTRIBUTIONS = gql`
 					symbol
 				}
 			}
+		}
+	}
+`;
+
+export const GET_INDEX_VALUES = gql`
+	query GetIndexValues($index: String!, $timestamp_gte: BigInt, $timestamp_lte: BigInt) {
+		indexUpdatedEvents(
+			where: { index: $index, timestamp_gte: $timestamp_gte, timestamp_lte: $timestamp_lte }
+			first: 1000
+		) {
+			newIndexValue
+			oldIndexValue
 		}
 	}
 `;

--- a/src/containers/main/TradeHistory/data/queries.ts
+++ b/src/containers/main/TradeHistory/data/queries.ts
@@ -32,6 +32,7 @@ export const GET_STREAMS_TERMINATED = gql`
 		) {
 			type
 			stream {
+				id
 				createdAtTimestamp
 				streamedUntilUpdatedAt
 				updatedAtTimestamp
@@ -45,6 +46,19 @@ export const GET_STREAMS_TERMINATED = gql`
 			totalAmountStreamedUntilTimestamp
 			transactionHash
 			id
+		}
+	}
+`;
+
+export const GET_STREAM_PERIODS = gql`
+	query Get_Stream_Periods($id_in: [ID!] = "") {
+		streamPeriods(where: { stream_: { id_in: $id_in } }, orderBy: startedAtTimestamp, orderDirection: desc) {
+			startedAtTimestamp
+			stoppedAtTimestamp
+			totalAmountStreamed
+			token {
+				symbol
+			}
 		}
 	}
 `;

--- a/src/containers/main/TradeHistory/data/queries.ts
+++ b/src/containers/main/TradeHistory/data/queries.ts
@@ -25,7 +25,7 @@ export const GET_STREAMS_CREATED = gql`
 export const GET_STREAMS_TERMINATED = gql`
 	query GetStreamsTerminated($sender: String!, $receivers: [String!]!) {
 		streams: flowUpdatedEvents(
-			where: { sender: $sender, receiver_in: $receivers, type: 2 }
+			where: { sender: $sender, receiver_in: $receivers }
 			orderBy: timestamp
 			orderDirection: desc
 			first: 100
@@ -52,7 +52,11 @@ export const GET_STREAMS_TERMINATED = gql`
 
 export const GET_STREAM_PERIODS = gql`
 	query Get_Stream_Periods($id_in: [ID!] = "") {
-		streamPeriods(where: { stream_: { id_in: $id_in } }, orderBy: startedAtTimestamp, orderDirection: desc) {
+		streamPeriods(
+			where: { stream_: { id_in: $id_in }, stoppedAtTimestamp_not: null }
+			orderBy: startedAtTimestamp
+			orderDirection: desc
+		) {
 			startedAtTimestamp
 			stoppedAtTimestamp
 			totalAmountStreamed

--- a/src/containers/main/TradeHistory/data/queries.ts
+++ b/src/containers/main/TradeHistory/data/queries.ts
@@ -22,8 +22,8 @@ export const GET_STREAMS_CREATED = gql`
 	}
 `;
 
-export const GET_STREAMS_TERMINATED = gql`
-	query GetStreamsTerminated($sender: String!, $receivers: [String!]!) {
+export const GET_STREAMS_WITH_FLOW_UPDATED_EVENTS = gql`
+	query GetStreamsWithFlowUpdatedEvents($sender: String!, $receivers: [String!]!) {
 		streams: flowUpdatedEvents(
 			where: { sender: $sender, receiver_in: $receivers }
 			orderBy: timestamp

--- a/src/containers/main/TradeHistory/data/queries.ts
+++ b/src/containers/main/TradeHistory/data/queries.ts
@@ -29,20 +29,22 @@ export const GET_STREAMS_WITH_FLOW_UPDATED_EVENTS = gql`
 			orderBy: timestamp
 			orderDirection: desc
 		) {
+			type
 			stream {
-				streamPeriods(
-					where: { stoppedAtTimestamp_not: null }
-					orderBy: startedAtTimestamp
-					orderDirection: desc
-				) {
-					startedAtTimestamp
-					stoppedAtTimestamp
-					token {
-						symbol
-					}
-					totalAmountStreamed
+				id
+				createdAtTimestamp
+				streamedUntilUpdatedAt
+				updatedAtTimestamp
+				token {
+					symbol
+					id
 				}
 			}
+			receiver
+			timestamp
+			totalAmountStreamedUntilTimestamp
+			transactionHash
+			id
 		}
 	}
 `;

--- a/src/containers/main/TradeHistory/types.ts
+++ b/src/containers/main/TradeHistory/types.ts
@@ -12,8 +12,8 @@ export interface Column {
 }
 
 export interface Data {
-	startDate: number;
-	endDate: number;
+	startDate: string;
+	endDate: string;
 	input: {
 		coin: Coin;
 		amount: number;
@@ -33,4 +33,5 @@ export interface Data {
 		percent: number;
 	};
 	updatedAtBlockNumber: number;
+	exchangeAddress: string;
 }


### PR DESCRIPTION
Fixes #754 

- [ ] get all `streams`, we need:
  - stream `id`.
- [ ] get `streamPeriods` by `id`, but omit the `streamPeriod` with `stoppedAtTimestamp` that has value `null` (active stream period), we need:
  - `startedAtTimestamp`
  - `stoppedAtTimestamp`
  - `totalAmountStreamed`
  - and token `symbol`.
- [ ] get `distribution` in range (`startedAtTimestamp`, `stoppedAtTimestamp`], and we need:
  - `block` to fetch current price.
- [ ] get started and stopped `transactionHash`.
- [ ] **TODO**