### PR TITLE
Sort Markets by total volume: Dework #55

### DIFF
--- a/src/containers/main/InvestContainer/InvestMarket.tsx
+++ b/src/containers/main/InvestContainer/InvestMarket.tsx
@@ -5,7 +5,7 @@ import { PanelChange } from 'components/layout/PanelChange';
 import { useTranslation } from 'react-i18next';
 import { ExchangeKeys } from 'utils/getExchangeAddress';
 import styles from './styles.module.scss';
-import { flowConfig, FlowEnum, RoutesToFlowTypes } from 'constants/flowConfig';
+import { flowConfig, FlowEnum, InvestmentFlow, RoutesToFlowTypes } from 'constants/flowConfig';
 import { useShallowSelector } from 'hooks/useShallowSelector';
 import { selectMain, selectUserStreams } from 'store/main/selectors';
 import { useRouteMatch } from 'react-router-dom';
@@ -27,7 +27,13 @@ export const InvestMarket: FC<InvestMarketProps> = ({ handleStart, handleStop })
 
 	useEffect(() => {
 		if (flowType) {
-			setFilteredList(flowConfig.filter((each) => each.type === flowType));
+			let sortedList = flowConfig.filter((each) => each.type === flowType);
+			sortedList = sortedList.sort((a, b) => {
+				const totalVolumeA = parseFloat(getFlowUSDValue(a));
+				const totalVolumeB = parseFloat(getFlowUSDValue(b));
+				return totalVolumeB - totalVolumeA;
+			});
+			setFilteredList(sortedList);
 		} else {
 			const sortedUserStreams = userStreams.sort((a, b) => {
 				const flowA = parseFloat(state[a.flowKey]?.placeholder || '0');
@@ -80,7 +86,12 @@ export const InvestMarket: FC<InvestMarketProps> = ({ handleStart, handleStop })
 
 	const streamEnds = computeStreamEnds(state, balances);
 
-	console.log('filteredList', filteredList);
+	function getFlowUSDValue(flow: InvestmentFlow, toFixed: number = 0) {
+		return (
+			coingeckoPrices ? parseFloat(state[flow.flowKey]?.flowsOwned as string) * coingeckoPrices[flow.tokenA] : 0
+		).toFixed(toFixed);
+	}
+
 	return (
 		<>
 			<div className={styles.input_wrap}>


### PR DESCRIPTION
Changes:
- The markets now sort by total volume (ie popularity) instead of the hard coded order.
